### PR TITLE
Feat/#20 paper approve modify

### DIFF
--- a/src/main/java/com/owl/payrit/domain/member/service/MemberService.java
+++ b/src/main/java/com/owl/payrit/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.owl.payrit.domain.member.entity.Member;
 import com.owl.payrit.domain.member.entity.OauthInformation;
 import com.owl.payrit.domain.member.exception.MemberException;
 import com.owl.payrit.domain.member.repository.MemberRepository;
+import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import com.owl.payrit.global.exception.ErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -80,4 +80,15 @@ public class PromissoryPaperRestController {
 
         return ResponseEntity.ok().body("modify request : %s".formatted(paperModifyRequest.contents()));
     }
+
+    @PutMapping("/modify/accept/{id}")
+    public ResponseEntity<String> modifying(@AuthenticationPrincipal LoginUser loginUser,
+                                            @PathVariable(value = "id") Long paperId,
+                                            @RequestBody PaperWriteRequest paperWriteRequest) {
+
+        //FIXME: 수정시에도 PaperWriteRequest를 요청?
+        promissoryPaperService.modifyingPaper(loginUser, paperId, paperWriteRequest);
+
+        return ResponseEntity.ok().body("modify success");
+    }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -56,10 +56,13 @@ public class PromissoryPaperRestController {
         return ResponseEntity.ok().body(allListResponses);
     }
 
-    @PutMapping("/approve/accept")
-    public ResponseEntity<String> acceptPaper(@AuthenticationPrincipal LoginUser loginUser) {
+    @PutMapping("/approve/accept/{id}")
+    public ResponseEntity<String> acceptPaper(@AuthenticationPrincipal LoginUser loginUser,
+                                              @PathVariable(value="id") Long paperId) {
 
         log.info("request user id : " + loginUser.id());
+
+        promissoryPaperService.acceptPaper(loginUser, paperId);
 
         return ResponseEntity.ok().body("accept");
     }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -5,7 +5,6 @@ import com.owl.payrit.domain.promissorypaper.dto.request.PaperModifyRequest;
 import com.owl.payrit.domain.promissorypaper.dto.request.PaperWriteRequest;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperDetailResponse;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperListResponse;
-import com.owl.payrit.domain.promissorypaper.entity.PaperRole;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,9 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -1,6 +1,7 @@
 package com.owl.payrit.domain.promissorypaper.controller;
 
 import com.owl.payrit.domain.auth.dto.response.LoginUser;
+import com.owl.payrit.domain.promissorypaper.dto.request.PaperModifyRequest;
 import com.owl.payrit.domain.promissorypaper.dto.request.PaperWriteRequest;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperDetailResponse;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperListResponse;
@@ -26,7 +27,7 @@ public class PromissoryPaperRestController {
 
     @PostMapping("/write")
     public ResponseEntity<String> write(@AuthenticationPrincipal LoginUser loginUser,
-                                             @RequestBody PaperWriteRequest paperWriteRequest) {
+                                        @RequestBody PaperWriteRequest paperWriteRequest) {
 
         log.info(paperWriteRequest.toString());
 
@@ -37,7 +38,7 @@ public class PromissoryPaperRestController {
 
     @GetMapping("/{id}")
     public ResponseEntity<PaperDetailResponse> detail(@AuthenticationPrincipal LoginUser loginUser,
-                                                      @PathVariable(value="id") Long id) {
+                                                      @PathVariable(value = "id") Long id) {
 
         log.info("request paper id : " + id);
 
@@ -58,12 +59,25 @@ public class PromissoryPaperRestController {
 
     @PutMapping("/approve/accept/{id}")
     public ResponseEntity<String> acceptPaper(@AuthenticationPrincipal LoginUser loginUser,
-                                              @PathVariable(value="id") Long paperId) {
+                                              @PathVariable(value = "id") Long paperId) {
 
         log.info("request user id : " + loginUser.id());
 
         promissoryPaperService.acceptPaper(loginUser, paperId);
 
         return ResponseEntity.ok().body("accept");
+    }
+
+    @PostMapping("/modify/request/{id}")
+    public ResponseEntity<String> requestModify(@AuthenticationPrincipal LoginUser loginUser,
+                                                @PathVariable(value = "id") Long paperId,
+                                                @RequestBody PaperModifyRequest paperModifyRequest) {
+
+        log.info("request user id : " + loginUser.id());
+        log.info("contents : " + paperModifyRequest.contents());
+
+        promissoryPaperService.sendModifyRequest(loginUser, paperId, paperModifyRequest);
+
+        return ResponseEntity.ok().body("modify request : %s".formatted(paperModifyRequest.contents()));
     }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -68,15 +68,14 @@ public class PromissoryPaperRestController {
         return ResponseEntity.ok().body("accept");
     }
 
-    @PostMapping("/modify/request/{id}")
+    @PostMapping("/modify/request")
     public ResponseEntity<String> requestModify(@AuthenticationPrincipal LoginUser loginUser,
-                                                @PathVariable(value = "id") Long paperId,
                                                 @RequestBody PaperModifyRequest paperModifyRequest) {
 
         log.info("request user id : " + loginUser.id());
         log.info("contents : " + paperModifyRequest.contents());
 
-        promissoryPaperService.sendModifyRequest(loginUser, paperId, paperModifyRequest);
+        promissoryPaperService.sendModifyRequest(loginUser, paperModifyRequest);
 
         return ResponseEntity.ok().body("modify request : %s".formatted(paperModifyRequest.contents()));
     }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -55,4 +55,12 @@ public class PromissoryPaperRestController {
 
         return ResponseEntity.ok().body(allListResponses);
     }
+
+    @PutMapping("/approve/accept")
+    public ResponseEntity<String> acceptPaper(@AuthenticationPrincipal LoginUser loginUser) {
+
+        log.info("request user id : " + loginUser.id());
+
+        return ResponseEntity.ok().body("accept");
+    }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/dto/request/PaperModifyRequest.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/dto/request/PaperModifyRequest.java
@@ -1,6 +1,8 @@
 package com.owl.payrit.domain.promissorypaper.dto.request;
 
 public record PaperModifyRequest(
+        Long paperId,
+        Long writerId,
         String contents
 ) {
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/dto/request/PaperModifyRequest.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/dto/request/PaperModifyRequest.java
@@ -1,0 +1,6 @@
+package com.owl.payrit.domain.promissorypaper.dto.request;
+
+public record PaperModifyRequest(
+        String contents
+) {
+}

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
@@ -69,4 +69,8 @@ public class PromissoryPaper extends BaseEntity {
 
     //저장소 URL
     private String storageUrl;
+
+    public void modifyPaperStatus(PaperStatus status) {
+        this.paperStatus = status;
+    }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
@@ -5,6 +5,7 @@ import com.owl.payrit.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 
@@ -14,6 +15,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 @ToString(callSuper = true)
+@DynamicUpdate
 public class PromissoryPaper extends BaseEntity {
 
     private long amount;

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -20,7 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -149,6 +149,10 @@ public class PromissoryPaperService {
 
         PromissoryPaper paper = getById(paperId);
 
+        if(!paper.getPaperStatus().equals(PaperStatus.WAITING_AGREE)) {
+            throw new PromissoryPaperException(ErrorCode.PAPER_STATUS_NOT_VALID);
+        }
+
         //나와 연관된 차용증에만 승인이 가능함
         if (!isMine(loginUser.id(), paper)) {
             throw new PromissoryPaperException(ErrorCode.PAPER_IS_NOT_MINE);
@@ -159,7 +163,7 @@ public class PromissoryPaperService {
             throw new PromissoryPaperException(ErrorCode.PAPER_CANNOT_ACCEPT_SELF);
         }
 
-        paper.modifyPaperStatus(PaperStatus.COMPLETE_WRITING);
+        paper.modifyPaperStatus(PaperStatus.PAYMENT_REQUIRED);
     }
 
     public PromissoryPaper getById(Long paperId) {

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -206,4 +206,38 @@ public class PromissoryPaperService {
 
         return paper.getCreditor();
     }
+
+    @Transactional
+    public void modifyingPaper(LoginUser loginUser, Long paperId, PaperWriteRequest paperWriteRequest) {
+
+        Member loginedMember = memberService.findById(loginUser.id());
+        PromissoryPaper paper = getById(paperId);
+
+        if(!paper.getPaperStatus().equals(PaperStatus.MODIFYING)) {
+            throw new PromissoryPaperException(ErrorCode.PAPER_STATUS_NOT_VALID);
+        }
+
+        if (!paper.getWriter().equals(loginedMember)) {
+            throw new PromissoryPaperException(ErrorCode.PAPER_WRITER_CAN_MODIFY);
+        }
+
+        //TODO: 더 좋은 방법 고려 필요. 수정할 부분이 어딘지 명시된다면?
+        PromissoryPaper modifiedPaper = paper.toBuilder()
+                .amount(paperWriteRequest.amount())
+                .transactionDate(paperWriteRequest.transactionDate())
+                .repaymentStartDate(paperWriteRequest.repaymentStartDate())
+                .repaymentEndDate(paperWriteRequest.repaymentEndDate())
+                .specialConditions(paperWriteRequest.specialConditions())
+                .interestRate(paperWriteRequest.interestRate())
+                .creditorName(paperWriteRequest.creditorName())
+                .creditorPhoneNumber(paperWriteRequest.creditorPhoneNumber())
+                .creditorAddress(paperWriteRequest.creditorAddress())
+                .debtorName(paperWriteRequest.debtorName())
+                .debtorPhoneNumber(paperWriteRequest.debtorPhoneNumber())
+                .debtorAddress(paperWriteRequest.debtorAddress())
+                .paperStatus(PaperStatus.WAITING_AGREE)
+                .build();
+
+        promissoryPaperRepository.save(modifiedPaper);
+    }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -175,10 +175,9 @@ public class PromissoryPaperService {
     }
 
     @Transactional
-    public void sendModifyRequest(LoginUser loginUser, Long paperId, PaperModifyRequest paperModifyRequest) {
+    public void sendModifyRequest(LoginUser loginUser, PaperModifyRequest paperModifyRequest) {
 
-        Member loginedMember = memberService.findById(loginUser.id());
-        PromissoryPaper paper = getById(paperId);
+        PromissoryPaper paper = getById(paperModifyRequest.paperId());
 
         //승인 대기 단계에서만 수정 요청이 가능함
         if (!paper.getPaperStatus().equals(PaperStatus.WAITING_AGREE)) {
@@ -190,21 +189,10 @@ public class PromissoryPaperService {
             throw new PromissoryPaperException(ErrorCode.PAPER_IS_NOT_MINE);
         }
 
-        Member peerMember = getPeerMember(paper, loginedMember);
-
-        //TODO: peerMember에게 paperModifyRequest의 contents로 알림(자체 or 알림톡) 발송하는 기능 필요
+        //TODO: 초기 작성자에게 paperModifyRequest의 contents로 알림(자체 or 알림톡) 발송하는 기능 필요
+        Member writer = memberService.findById(paperModifyRequest.writerId());
 
         paper.modifyPaperStatus(PaperStatus.MODIFYING);
-    }
-
-    //FIXME: MemberService 로 위치 이동 필요?
-    private Member getPeerMember(PromissoryPaper paper, Member loginedMember) {
-
-        if (paper.getCreditor().equals(loginedMember)) {
-            return paper.getDebtor();
-        }
-
-        return paper.getCreditor();
     }
 
     @Transactional

--- a/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
+++ b/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     PAPER_IS_NOT_MINE(HttpStatus.FORBIDDEN, "차용증 접근 권한이 없습니다."),
     PAPER_LIST_EXCEPTION(HttpStatus.BAD_REQUEST, "차용증 리스트 조회가 올바르지 않습니다."),
     PAPER_CANNOT_ACCEPT_SELF(HttpStatus.BAD_REQUEST, "작성자는 승인할 수 없습니다."),
-    PAPER_STATUS_NOT_VALID(HttpStatus.BAD_REQUEST, "차용증에 대한 요청 단계가 올바르지 않습니다.");
+    PAPER_STATUS_NOT_VALID(HttpStatus.BAD_REQUEST, "차용증에 대한 요청 단계가 올바르지 않습니다."),
+    PAPER_WRITER_CAN_MODIFY(HttpStatus.FORBIDDEN, "첫 작성자만 수정이 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
+++ b/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "차용증 정보가 존재하지 않습니다."),
     PAPER_IS_NOT_MINE(HttpStatus.FORBIDDEN, "차용증 접근 권한이 없습니다."),
     PAPER_LIST_EXCEPTION(HttpStatus.BAD_REQUEST, "차용증 리스트 조회가 올바르지 않습니다."),
-    PAPER_CANNOT_ACCEPT_SELF(HttpStatus.BAD_REQUEST, "작성자는 승인할 수 없습니다.");
+    PAPER_CANNOT_ACCEPT_SELF(HttpStatus.BAD_REQUEST, "작성자는 승인할 수 없습니다."),
+    PAPER_STATUS_NOT_VALID(HttpStatus.BAD_REQUEST, "차용증에 대한 요청 단계가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
+++ b/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."),
     PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "차용증 정보가 존재하지 않습니다."),
     PAPER_IS_NOT_MINE(HttpStatus.FORBIDDEN, "차용증 접근 권한이 없습니다."),
-    PAPER_LIST_EXCEPTION(HttpStatus.BAD_REQUEST, "차용증 리스트 조회가 올바르지 않습니다.");
+    PAPER_LIST_EXCEPTION(HttpStatus.BAD_REQUEST, "차용증 리스트 조회가 올바르지 않습니다."),
+    PAPER_CANNOT_ACCEPT_SELF(HttpStatus.BAD_REQUEST, "작성자는 승인할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;


### PR DESCRIPTION
- 승인 요청을 받은 유저는 차용증의 내용이 올바르다고 판단했을 때, 승인 버튼을 눌러 결제 대기 상태로 변환시킬 수 있습니다.
  - 차용증과 연관된 사람만 승인할 수 있습니다.
  - 차용증의 첫 작성자는 승인할 수 없습니다.
  - 차용증의 상태가 "승인 대기중(WAITING_AGREE)" 인 경우에만 승인이 가능합니다. (수정중 불가)


- 만약 위의 유저가 올바르지 않다고 판단 했을 때, 간단한 메세지와 함께 상대방에게 수정 요청을 보낼 수 있습니다.
  - 실제로 알림(자체알림 혹은 채널톡)을 보내는 기능은 아직 미구현 되었습니다.(Sprint3 구현 예정)
  - 차용증의 상태가 "승인 대기중(WAITING_AGREE)" 인 경우에만 요청이 가능합니다.
  - 차용증의 상태가 "수정중(MODIFYING)"으로 변경됩니다.


- 수정 요청을 받은 첫 작성자는 폼 데이터를 다시 입력해 차용증의 수정을 진행할 수 있습니다.
  - 수정을 완료하면 상태가 수정중 -> 승인 대기중으로 변경됩니다.
  - 첫 작성자만 수정 작업이 가능합니다.

---
기타
  - 수정시, Write 의 경우와 같은 폼을 쓰고 있고, 전체 내용을 변경사항이 없더라도 모두
  덮어 씌우는 비효율적인 방법을 채택중 입니다. 좋은 방법을 통해 리팩토링이 필요해 보입니다.

### 연결 이슈
#20 