### PR TITLE
이자 계산 및 일부 상환 기능 구현

### DIFF
--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -6,7 +6,9 @@ import com.owl.payrit.domain.promissorypaper.dto.request.PaperWriteRequest;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperDetailResponse;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperListResponse;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
+import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -86,5 +88,14 @@ public class PromissoryPaperRestController {
         promissoryPaperService.modifyingPaper(loginUser, paperId, paperWriteRequest);
 
         return ResponseEntity.ok().body("modify success");
+    }
+
+    @PostMapping("/repayment/request")
+    public ResponseEntity<String> repaymentRequest(@AuthenticationPrincipal LoginUser loginUser,
+                                                   @RequestBody RepaymentRequest repaymentRequest) {
+
+        promissoryPaperService.repayment(loginUser, repaymentRequest);
+
+        return ResponseEntity.ok().body("repayment success");
     }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/controller/PromissoryPaperRestController.java
@@ -6,6 +6,7 @@ import com.owl.payrit.domain.promissorypaper.dto.request.PaperWriteRequest;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperDetailResponse;
 import com.owl.payrit.domain.promissorypaper.dto.response.PaperListResponse;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
+import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentCancelRequest;
 import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
@@ -97,5 +98,14 @@ public class PromissoryPaperRestController {
         promissoryPaperService.repayment(loginUser, repaymentRequest);
 
         return ResponseEntity.ok().body("repayment success");
+    }
+
+    @PostMapping("/repayment/cancel")
+    public ResponseEntity<String> repaymentCancel(@AuthenticationPrincipal LoginUser loginUser,
+                                                  @RequestBody RepaymentCancelRequest repaymentCancelRequest) {
+
+        promissoryPaperService.cancelRepayment(loginUser, repaymentCancelRequest);
+
+        return ResponseEntity.ok().body("repayment canceled");
     }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/dto/response/PaperDetailResponse.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/dto/response/PaperDetailResponse.java
@@ -1,8 +1,10 @@
 package com.owl.payrit.domain.promissorypaper.dto.response;
 
 import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
+import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record PaperDetailResponse(
 
@@ -19,7 +21,8 @@ public record PaperDetailResponse(
         String debtorName,
         String debtorPhoneNumber,
         String debtorAddress,
-        String specialConditions
+        String specialConditions,
+        List<RepaymentHistory> repaymentHistories
 ) {
     public PaperDetailResponse(PromissoryPaper promissoryPaper, double repaymentRate) {
         this(
@@ -36,7 +39,8 @@ public record PaperDetailResponse(
                 promissoryPaper.getDebtor().getName(),
                 promissoryPaper.getDebtorPhoneNumber(),
                 promissoryPaper.getDebtorAddress(),
-                promissoryPaper.getSpecialConditions()
+                promissoryPaper.getSpecialConditions(),
+                promissoryPaper.getRepaymentHistory()
         );
     }
 }

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/dto/response/PaperDetailResponse.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/dto/response/PaperDetailResponse.java
@@ -5,13 +5,11 @@ import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import java.time.LocalDate;
 
 public record PaperDetailResponse(
-        //FIXME: 단순 Paper객체가 아닌 Response를 반환하는 것과의 차이점...?
 
         String paperUrl,
-        long totalAmount,
+        long remainingAmount,
         float interestRate,
         double repaymentRate,
-        long currentRepaymentAmount,
         LocalDate repaymentStartDate,
         LocalDate repaymentEndDate,
         String creditorName,
@@ -25,10 +23,9 @@ public record PaperDetailResponse(
     public PaperDetailResponse(PromissoryPaper promissoryPaper, double repaymentRate) {
         this(
                 promissoryPaper.getStorageUrl(),
-                promissoryPaper.getAmount(),
+                promissoryPaper.getRemainingAmount(),
                 promissoryPaper.getInterestRate(),
                 repaymentRate,
-                promissoryPaper.getRepaymentAmount(),
                 promissoryPaper.getRepaymentStartDate(),
                 promissoryPaper.getRepaymentEndDate(),
                 promissoryPaper.getCreditor().getName(),

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/dto/response/PaperDetailResponse.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/dto/response/PaperDetailResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 public record PaperDetailResponse(
 
         String paperUrl,
+        long amount,
         long remainingAmount,
         float interestRate,
         double repaymentRate,
@@ -23,6 +24,7 @@ public record PaperDetailResponse(
     public PaperDetailResponse(PromissoryPaper promissoryPaper, double repaymentRate) {
         this(
                 promissoryPaper.getStorageUrl(),
+                promissoryPaper.getAmount(),
                 promissoryPaper.getRemainingAmount(),
                 promissoryPaper.getInterestRate(),
                 repaymentRate,

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
@@ -1,5 +1,6 @@
 package com.owl.payrit.domain.promissorypaper.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.owl.payrit.domain.member.entity.Member;
 import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import com.owl.payrit.global.entity.BaseEntity;
@@ -24,7 +25,8 @@ public class PromissoryPaper extends BaseEntity {
 
     private long remainingAmount;
 
-    @OneToMany(mappedBy = "paper")
+    @JsonManagedReference
+    @OneToMany(mappedBy = "paper", fetch = FetchType.LAZY)
     private List<RepaymentHistory> repaymentHistory;
 
     private LocalDate transactionDate;

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
@@ -20,6 +20,8 @@ public class PromissoryPaper extends BaseEntity {
 
     private long amount;
 
+    private long remainingAmount;
+
     private LocalDate transactionDate;
 
     private LocalDate repaymentStartDate;
@@ -29,9 +31,6 @@ public class PromissoryPaper extends BaseEntity {
     private String specialConditions;
 
     private float interestRate;
-
-    @Builder.Default
-    private long repaymentAmount = 0;
 
     //차용증을 누가 작성했는지
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/entity/PromissoryPaper.java
@@ -1,6 +1,7 @@
 package com.owl.payrit.domain.promissorypaper.entity;
 
 import com.owl.payrit.domain.member.entity.Member;
+import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import com.owl.payrit.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -8,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,6 +24,9 @@ public class PromissoryPaper extends BaseEntity {
 
     private long remainingAmount;
 
+    @OneToMany(mappedBy = "paper")
+    private List<RepaymentHistory> repaymentHistory;
+
     private LocalDate transactionDate;
 
     private LocalDate repaymentStartDate;
@@ -32,7 +37,6 @@ public class PromissoryPaper extends BaseEntity {
 
     private float interestRate;
 
-    //차용증을 누가 작성했는지
     @ManyToOne(fetch = FetchType.LAZY)
     private Member writer;
 

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -57,10 +57,11 @@ public class PromissoryPaperService {
                 paperWriteRequest.debtorPhoneNumber()).orElse(null);
 
         long amount = paperWriteRequest.amount();
+        long calcAmount = amount + calcInterest(amount, paperWriteRequest.interestRate());
 
         PromissoryPaper paper = PromissoryPaper.builder()
-                .amount(amount)
-                .remainingAmount(amount + calcInterest(amount, paperWriteRequest.interestRate()))
+                .amount(calcAmount)
+                .remainingAmount(calcAmount)
                 .transactionDate(paperWriteRequest.transactionDate())
                 .repaymentStartDate(paperWriteRequest.repaymentStartDate())
                 .repaymentEndDate(paperWriteRequest.repaymentEndDate())

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -294,14 +294,12 @@ public class PromissoryPaperService {
     public double calcRepaymentRate(PromissoryPaper paper) {
 
         //FIXME: 상환 내역 생성 후 수정 필요
-//        long amount = paper.getAmount();
-//        long remainingAmount
-//
-//        double repaymentRate = (double) currentRepaymentAmount / amount * 100.0;
-//
-//        return Math.round(repaymentRate * 100.0) / 100.0;
+        long amount = paper.getAmount();
+        long needToRepaymentAmount = amount - paper.getRemainingAmount();
 
-        return 0.0;
+        double repaymentRate = (double) needToRepaymentAmount / amount * 100.0;
+
+        return Math.round(repaymentRate * 100.0) / 100.0;
     }
 
     @Transactional

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -94,16 +94,16 @@ public class PromissoryPaperService {
         return promissoryPaperRepository.existsByPaperKey(paperKey) ? getRandomKey() : paperKey;
     }
 
-//    public PaperDetailResponse getDetail(LoginUser loginUser, Long paperId) {
-//
-//        PromissoryPaper promissoryPaper = getById(paperId);
-//
-//        if (!isMine(loginUser.id(), promissoryPaper)) {
-//            throw new PromissoryPaperException(ErrorCode.PAPER_IS_NOT_MINE);
-//        }
-//
-//        return new PaperDetailResponse(promissoryPaper, calcRepaymentRate(promissoryPaper));
-//    }
+    public PaperDetailResponse getDetail(LoginUser loginUser, Long paperId) {
+
+        PromissoryPaper promissoryPaper = getById(paperId);
+
+        if (!isMine(loginUser.id(), promissoryPaper)) {
+            throw new PromissoryPaperException(ErrorCode.PAPER_IS_NOT_MINE);
+        }
+
+        return new PaperDetailResponse(promissoryPaper, calcRepaymentRate(promissoryPaper));
+    }
 
     private boolean isMine(Long memberId, PromissoryPaper promissoryPaper) {
 
@@ -115,40 +115,40 @@ public class PromissoryPaperService {
         return false;
     }
 
-//    public List<PaperListResponse> getAllListResponse(LoginUser loginUser) {
-//
-//        List<PaperListResponse> creditorList =
-//                getListResponsesByRole(loginUser, PaperRole.CREDITOR);
-//
-//        List<PaperListResponse> debtorList =
-//                getListResponsesByRole(loginUser, PaperRole.DEBTOR);
-//
-//        return Stream.concat(creditorList.stream(), debtorList.stream())
-//                .collect(Collectors.toList());
-//    }
+    public List<PaperListResponse> getAllListResponse(LoginUser loginUser) {
 
-//    public List<PaperListResponse> getListResponsesByRole(LoginUser loginUser, PaperRole role) {
-//
-//        Member loginedMember = memberService.findById(loginUser.id());
-//
-//        List<PromissoryPaper> papers;
-//
-//        if (role.equals(PaperRole.CREDITOR)) {
-//            papers = promissoryPaperRepository.findAllByCreditor(loginedMember);
-//        } else {
-//            papers = promissoryPaperRepository.findAllByDebtor(loginedMember);
-//        }
-//
-//        return papers.stream().map(paper -> {
-//            if (role.equals(PaperRole.CREDITOR)) {
-//                return new PaperListResponse(paper, PaperRole.CREDITOR, paper.getDebtorName(),
-//                        calcDueDate(paper), calcRepaymentRate(paper));
-//            } else {
-//                return new PaperListResponse(paper, PaperRole.DEBTOR, paper.getCreditorName()
-//                        , calcDueDate(paper), calcRepaymentRate(paper));
-//            }
-//        }).collect(Collectors.toList());
-//    }
+        List<PaperListResponse> creditorList =
+                getListResponsesByRole(loginUser, PaperRole.CREDITOR);
+
+        List<PaperListResponse> debtorList =
+                getListResponsesByRole(loginUser, PaperRole.DEBTOR);
+
+        return Stream.concat(creditorList.stream(), debtorList.stream())
+                .collect(Collectors.toList());
+    }
+
+    public List<PaperListResponse> getListResponsesByRole(LoginUser loginUser, PaperRole role) {
+
+        Member loginedMember = memberService.findById(loginUser.id());
+
+        List<PromissoryPaper> papers;
+
+        if (role.equals(PaperRole.CREDITOR)) {
+            papers = promissoryPaperRepository.findAllByCreditor(loginedMember);
+        } else {
+            papers = promissoryPaperRepository.findAllByDebtor(loginedMember);
+        }
+
+        return papers.stream().map(paper -> {
+            if (role.equals(PaperRole.CREDITOR)) {
+                return new PaperListResponse(paper, PaperRole.CREDITOR, paper.getDebtorName(),
+                        calcDueDate(paper), calcRepaymentRate(paper));
+            } else {
+                return new PaperListResponse(paper, PaperRole.DEBTOR, paper.getCreditorName()
+                        , calcDueDate(paper), calcRepaymentRate(paper));
+            }
+        }).collect(Collectors.toList());
+    }
 
     private long calcDueDate(PromissoryPaper paper) {
 
@@ -285,16 +285,19 @@ public class PromissoryPaperService {
         }
     }
 
-    //FIXME: 상환 내역 생성 후 수정 필요
-//    public double calcRepaymentRate(PromissoryPaper paper) {
-//
+
+    public double calcRepaymentRate(PromissoryPaper paper) {
+
+        //FIXME: 상환 내역 생성 후 수정 필요
 //        long amount = paper.getAmount();
-//        long currentRepaymentAmount = paper.getRepaymentAmount();
+//        long remainingAmount
 //
 //        double repaymentRate = (double) currentRepaymentAmount / amount * 100.0;
 //
 //        return Math.round(repaymentRate * 100.0) / 100.0;
-//    }
+
+        return 0.0;
+    }
 
     @Transactional
     @Scheduled(cron = "0 0 0 * * ?")

--- a/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
+++ b/src/main/java/com/owl/payrit/domain/promissorypaper/service/PromissoryPaperService.java
@@ -323,8 +323,9 @@ public class PromissoryPaperService {
     public void repayment(LoginUser loginUser, RepaymentRequest repaymentRequest) {
 
         PromissoryPaper paper = getById(repaymentRequest.paperId());
+        Member loginedMember = memberService.findById(loginUser.id());
 
-        repaymentHistoryService.create(paper, repaymentRequest);
+        repaymentHistoryService.create(loginedMember, paper, repaymentRequest);
 
         PromissoryPaper modifiedPaper = paper.toBuilder()
                 .remainingAmount(paper.getRemainingAmount() - repaymentRequest.repaymentAmount())

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/dto/request/RepaymentCancelRequest.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/dto/request/RepaymentCancelRequest.java
@@ -1,0 +1,7 @@
+package com.owl.payrit.domain.repaymenthistory.dto.request;
+
+public record RepaymentCancelRequest(
+        Long paperId,
+        Long historyId
+) {
+}

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/dto/request/RepaymentRequest.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/dto/request/RepaymentRequest.java
@@ -1,0 +1,11 @@
+package com.owl.payrit.domain.repaymenthistory.dto.request;
+
+import java.time.LocalDate;
+
+public record RepaymentRequest(
+
+        long paperId,
+        LocalDate repaymentDate,
+        long repaymentAmount
+) {
+}

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
@@ -27,7 +27,5 @@ public class RepaymentHistory extends BaseEntity {
 
     private LocalDate repaymentDate;
 
-    private int repaymentRound;
-
     private long repaymentAmount;
 }

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
@@ -1,0 +1,31 @@
+package com.owl.payrit.domain.repaymenthistory.entity;
+
+import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
+import com.owl.payrit.global.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+@ToString(callSuper = true)
+public class RepaymentHistory extends BaseEntity {
+
+    @ManyToOne
+    private PromissoryPaper paper;
+
+    private LocalDate repaymentDate;
+
+    private long repaymentRound;
+
+    private long repaymentAmount;
+}

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
@@ -3,6 +3,8 @@ package com.owl.payrit.domain.repaymenthistory.entity;
 import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import com.owl.payrit.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,7 +27,7 @@ public class RepaymentHistory extends BaseEntity {
 
     private LocalDate repaymentDate;
 
-    private long repaymentRound;
+    private int repaymentRound;
 
     private long repaymentAmount;
 }

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/entity/RepaymentHistory.java
@@ -1,11 +1,9 @@
 package com.owl.payrit.domain.repaymenthistory.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import com.owl.payrit.global.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +20,8 @@ import java.time.LocalDate;
 @ToString(callSuper = true)
 public class RepaymentHistory extends BaseEntity {
 
-    @ManyToOne
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
     private PromissoryPaper paper;
 
     private LocalDate repaymentDate;

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/repository/RepaymentHistoryRepository.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/repository/RepaymentHistoryRepository.java
@@ -1,7 +1,10 @@
 package com.owl.payrit.domain.repaymenthistory.repository;
 
+import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RepaymentHistoryRepository extends JpaRepository<RepaymentHistory, Long> {
+
+    int countByPaper(PromissoryPaper paper);
 }

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/repository/RepaymentHistoryRepository.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/repository/RepaymentHistoryRepository.java
@@ -5,6 +5,4 @@ import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RepaymentHistoryRepository extends JpaRepository<RepaymentHistory, Long> {
-
-    int countByPaper(PromissoryPaper paper);
 }

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/repository/RepaymentHistoryRepository.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/repository/RepaymentHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.owl.payrit.domain.repaymenthistory.repository;
+
+import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepaymentHistoryRepository extends JpaRepository<RepaymentHistory, Long> {
+}

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
@@ -1,6 +1,7 @@
 package com.owl.payrit.domain.repaymenthistory.service;
 
 import com.owl.payrit.domain.member.entity.Member;
+import com.owl.payrit.domain.promissorypaper.entity.PaperStatus;
 import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import com.owl.payrit.domain.promissorypaper.exception.PromissoryPaperException;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
@@ -42,6 +43,10 @@ public class RepaymentHistoryService {
         LocalDate requestDate = repaymentRequest.repaymentDate();
         LocalDate repaymentStartDate = paper.getRepaymentStartDate();
         LocalDate repaymentEndDate = paper.getRepaymentEndDate();
+
+        if(!paper.getPaperStatus().equals(PaperStatus.COMPLETE_WRITING)){
+            throw new PromissoryPaperException(ErrorCode.REPAYMENT_STATUS_ERROR);
+        }
 
         if(!paper.getCreditor().equals(member)) {
             throw new PromissoryPaperException(ErrorCode.REPAYMENT_ONLY_ACCESS_CREDITOR);

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
@@ -1,5 +1,9 @@
 package com.owl.payrit.domain.repaymenthistory.service;
 
+import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
+import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
+import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentRequest;
+import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import com.owl.payrit.domain.repaymenthistory.repository.RepaymentHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,4 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class RepaymentHistoryService {
 
     private final RepaymentHistoryRepository repaymentHistoryRepository;
+
+    @Transactional
+    public void create(PromissoryPaper paper, RepaymentRequest repaymentRequest) {
+
+        RepaymentHistory repaymentHistory = RepaymentHistory.builder()
+                .paper(paper)
+                .repaymentAmount(repaymentRequest.repaymentAmount())
+                .repaymentDate(repaymentRequest.repaymentDate())
+                .repaymentRound(repaymentHistoryRepository.countByPaper(paper) + 1)
+                .build();
+
+        repaymentHistoryRepository.save(repaymentHistory);
+    }
 }

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
@@ -1,0 +1,16 @@
+package com.owl.payrit.domain.repaymenthistory.service;
+
+import com.owl.payrit.domain.repaymenthistory.repository.RepaymentHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RepaymentHistoryService {
+
+    private final RepaymentHistoryRepository repaymentHistoryRepository;
+}

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
@@ -25,7 +25,6 @@ public class RepaymentHistoryService {
                 .paper(paper)
                 .repaymentAmount(repaymentRequest.repaymentAmount())
                 .repaymentDate(repaymentRequest.repaymentDate())
-                .repaymentRound(repaymentHistoryRepository.countByPaper(paper) + 1)
                 .build();
 
         repaymentHistoryRepository.save(repaymentHistory);

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
@@ -1,14 +1,19 @@
 package com.owl.payrit.domain.repaymenthistory.service;
 
+import com.owl.payrit.domain.member.entity.Member;
 import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
+import com.owl.payrit.domain.promissorypaper.exception.PromissoryPaperException;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
 import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentRequest;
 import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import com.owl.payrit.domain.repaymenthistory.repository.RepaymentHistoryRepository;
+import com.owl.payrit.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 @Slf4j
@@ -19,7 +24,9 @@ public class RepaymentHistoryService {
     private final RepaymentHistoryRepository repaymentHistoryRepository;
 
     @Transactional
-    public void create(PromissoryPaper paper, RepaymentRequest repaymentRequest) {
+    public void create(Member member, PromissoryPaper paper, RepaymentRequest repaymentRequest) {
+
+        checkRepaymentConditions(member, paper, repaymentRequest);
 
         RepaymentHistory repaymentHistory = RepaymentHistory.builder()
                 .paper(paper)
@@ -28,5 +35,24 @@ public class RepaymentHistoryService {
                 .build();
 
         repaymentHistoryRepository.save(repaymentHistory);
+    }
+
+    public void checkRepaymentConditions(Member member, PromissoryPaper paper, RepaymentRequest repaymentRequest) {
+
+        LocalDate requestDate = repaymentRequest.repaymentDate();
+        LocalDate repaymentStartDate = paper.getRepaymentStartDate();
+        LocalDate repaymentEndDate = paper.getRepaymentEndDate();
+
+        if(!paper.getCreditor().equals(member)) {
+            throw new PromissoryPaperException(ErrorCode.REPAYMENT_ONLY_ACCESS_CREDITOR);
+        }
+
+        if(requestDate.isBefore(repaymentStartDate) || requestDate.isAfter(repaymentEndDate)) {
+            throw new PromissoryPaperException(ErrorCode.REPAYMENT_NOT_VALID_DATE);
+        }
+
+        if(paper.getRemainingAmount() < repaymentRequest.repaymentAmount()) {
+            throw new PromissoryPaperException(ErrorCode.REPAYMENT_AMOUNT_OVER);
+        }
     }
 }

--- a/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
+++ b/src/main/java/com/owl/payrit/domain/repaymenthistory/service/RepaymentHistoryService.java
@@ -5,6 +5,7 @@ import com.owl.payrit.domain.promissorypaper.entity.PaperStatus;
 import com.owl.payrit.domain.promissorypaper.entity.PromissoryPaper;
 import com.owl.payrit.domain.promissorypaper.exception.PromissoryPaperException;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
+import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentCancelRequest;
 import com.owl.payrit.domain.repaymenthistory.dto.request.RepaymentRequest;
 import com.owl.payrit.domain.repaymenthistory.entity.RepaymentHistory;
 import com.owl.payrit.domain.repaymenthistory.repository.RepaymentHistoryRepository;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -59,5 +61,17 @@ public class RepaymentHistoryService {
         if(paper.getRemainingAmount() < repaymentRequest.repaymentAmount()) {
             throw new PromissoryPaperException(ErrorCode.REPAYMENT_AMOUNT_OVER);
         }
+    }
+
+    @Transactional
+    public void remove(RepaymentHistory repaymentHistory) {
+
+        repaymentHistoryRepository.delete(repaymentHistory);
+    }
+
+    public RepaymentHistory getById(Long historyId) {
+
+        return repaymentHistoryRepository.findById(historyId).orElseThrow(
+                () -> new PromissoryPaperException(ErrorCode.REPAYMENT_HISTORY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
+++ b/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     PAPER_WRITER_CAN_MODIFY(HttpStatus.FORBIDDEN, "첫 작성자만 수정이 가능합니다."),
     PAPER_MATCHING_FAILED(HttpStatus.BAD_REQUEST, "차용증 정보와 회원의 정보가 일치하지 않습니다."),
     PAPER_DATA_BAD_REQUEST(HttpStatus.BAD_REQUEST, "차용증 데이터가 올바르지 않습니다."),
+    REPAYMENT_STATUS_ERROR(HttpStatus.BAD_REQUEST, "상환은 차용증 작성이 완료되었을 때만 가능합니다."),
     REPAYMENT_ONLY_ACCESS_CREDITOR(HttpStatus.BAD_REQUEST, "일부 상환은 채권자만 기록할 수 있습니다."),
     REPAYMENT_NOT_VALID_DATE(HttpStatus.BAD_REQUEST, "일부 상환 일자가 차용증과 일치하지 않습니다."),
     REPAYMENT_AMOUNT_OVER(HttpStatus.BAD_REQUEST, "상환 기록액이 남은 금액을 초과합니다.");

--- a/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
+++ b/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     PAPER_WRITER_CAN_MODIFY(HttpStatus.FORBIDDEN, "첫 작성자만 수정이 가능합니다."),
     PAPER_MATCHING_FAILED(HttpStatus.BAD_REQUEST, "차용증 정보와 회원의 정보가 일치하지 않습니다."),
     PAPER_DATA_BAD_REQUEST(HttpStatus.BAD_REQUEST, "차용증 데이터가 올바르지 않습니다."),
+    REPAYMENT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "상환 기록이 존재하지 않습니다."),
     REPAYMENT_STATUS_ERROR(HttpStatus.BAD_REQUEST, "상환은 차용증 작성이 완료되었을 때만 가능합니다."),
     REPAYMENT_ONLY_ACCESS_CREDITOR(HttpStatus.BAD_REQUEST, "일부 상환은 채권자만 기록할 수 있습니다."),
     REPAYMENT_NOT_VALID_DATE(HttpStatus.BAD_REQUEST, "일부 상환 일자가 차용증과 일치하지 않습니다."),

--- a/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
+++ b/src/main/java/com/owl/payrit/global/exception/ErrorCode.java
@@ -17,7 +17,10 @@ public enum ErrorCode {
     PAPER_STATUS_NOT_VALID(HttpStatus.BAD_REQUEST, "차용증에 대한 요청 단계가 올바르지 않습니다."),
     PAPER_WRITER_CAN_MODIFY(HttpStatus.FORBIDDEN, "첫 작성자만 수정이 가능합니다."),
     PAPER_MATCHING_FAILED(HttpStatus.BAD_REQUEST, "차용증 정보와 회원의 정보가 일치하지 않습니다."),
-    PAPER_DATA_BAD_REQUEST(HttpStatus.BAD_REQUEST, "차용증 데이터가 올바르지 않습니다.");
+    PAPER_DATA_BAD_REQUEST(HttpStatus.BAD_REQUEST, "차용증 데이터가 올바르지 않습니다."),
+    REPAYMENT_ONLY_ACCESS_CREDITOR(HttpStatus.BAD_REQUEST, "일부 상환은 채권자만 기록할 수 있습니다."),
+    REPAYMENT_NOT_VALID_DATE(HttpStatus.BAD_REQUEST, "일부 상환 일자가 차용증과 일치하지 않습니다."),
+    REPAYMENT_AMOUNT_OVER(HttpStatus.BAD_REQUEST, "상환 기록액이 남은 금액을 초과합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;


### PR DESCRIPTION
연결 이슈
#29 

## 일부 상환, 이자 계산 기능 구현

### TODO

1. 일부 상환 기능
    - [x] PromissoryPaper 엔티티에서 repaymentAmount(현재 상환액) 삭제 후 남은 금액으로 대체
    - [x] 일부 상환 기록은 채권자만 남길 수 있다.
    - [x] 상환 날짜가 유효해야 한다.
    - [x] 상환 금액은 남은 잔액을 초과할 수 없다.
    - [x] 송금 날짜, 상환 회차, 상환 금액을 기반으로 한 엔티티 구성
    - [x] 사용자는 차용증에 일부 상환에 대한 내용을 기록할 수 있다.
    - [x] 기록 후 실제 paper 객체의 남은 금액이 수정되어야 한다.
    - [x] 작성이 완료된 상태에서만 일부 상환이 가능하다.
    - [x] 기록 삭제 기능
      - [x] 삭제한 만큼 잔액도 복구되어야 함.

3. 이자 계산 기능
    - [x] 초기 작성시 설정한 이자에 따라 상세 페이지에서 확인되는 원금이 (혹은 갚아야 할 내용이) 변경되어야 한다.
    - [x] 리스트 확인시에도 이자를 포함한 금액으로 표기되어야 한다.

## 기타사항