### PR TITLE
Feat : 본인인증 1차 구현

### DIFF
--- a/src/main/java/com/owl/payrit/domain/auth/controller/AuthApiDocs.java
+++ b/src/main/java/com/owl/payrit/domain/auth/controller/AuthApiDocs.java
@@ -1,6 +1,7 @@
 package com.owl.payrit.domain.auth.controller;
 
 import com.owl.payrit.domain.auth.domain.OauthProvider;
+import com.owl.payrit.domain.auth.dto.request.CertificationRequest;
 import com.owl.payrit.domain.auth.dto.request.LoginTokenRequest;
 import com.owl.payrit.domain.auth.dto.request.RevokeRequest;
 import com.owl.payrit.domain.auth.dto.response.LoginUser;
@@ -50,4 +51,8 @@ public interface AuthApiDocs {
             @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))
         })
     ResponseEntity<TokenRefreshResponse> refreshAccessToken(LoginTokenRequest loginTokenRequest);
+
+    @Operation(summary = "본인 인증 완료 API", description = "본인인증이 성공한 유저에 대해서, 서버에 정보를 등록하는 API 입니다. 본인인증이 성공한 뒤, Imp_uid를 body에 담아서 전송하면 서버에서 PortOne 서버로 인증 정보를 요청합니다.")
+    @ApiResponse(responseCode = "204")
+    ResponseEntity<Void> initializeCertificationInformation(@AuthenticationPrincipal LoginUser loginUser, @RequestBody CertificationRequest certificationRequest);
 }

--- a/src/main/java/com/owl/payrit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/owl/payrit/domain/auth/controller/AuthController.java
@@ -76,12 +76,11 @@ public class AuthController implements AuthApiDocs{
         return ResponseEntity.ok().body(tokenResponse);
     }
 
+    @Override
     @PostMapping("/certification/init")
     public ResponseEntity<Void> initializeCertificationInformation(@AuthenticationPrincipal LoginUser loginUser, @RequestBody CertificationRequest certificationRequest) {
         log.info("'{}' user requests to register certification information" , loginUser.oauthInformation().getOauthProviderId());
-
         authService.initializeCertificationInformation(loginUser, certificationRequest);
-
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/owl/payrit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/owl/payrit/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.owl.payrit.domain.auth.controller;
 
 import com.owl.payrit.domain.auth.domain.OauthProvider;
+import com.owl.payrit.domain.auth.dto.request.CertificationRequest;
 import com.owl.payrit.domain.auth.dto.request.LoginTokenRequest;
 import com.owl.payrit.domain.auth.dto.request.RevokeRequest;
 import com.owl.payrit.domain.auth.dto.response.LoginUser;
@@ -73,6 +74,15 @@ public class AuthController implements AuthApiDocs{
         log.info("user request refresh AccessToken");
         TokenRefreshResponse tokenResponse = authService.refreshAccessToken(loginTokenRequest);
         return ResponseEntity.ok().body(tokenResponse);
+    }
+
+    @PostMapping("/certification/init")
+    public ResponseEntity<Void> initializeCertificationInformation(@AuthenticationPrincipal LoginUser loginUser, @RequestBody CertificationRequest certificationRequest) {
+        log.info("'{}' user requests to register certification information" , loginUser.oauthInformation().getOauthProviderId());
+
+        authService.initializeCertificationInformation(loginUser, certificationRequest);
+
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/src/main/java/com/owl/payrit/domain/auth/dto/request/CertificationRequest.java
+++ b/src/main/java/com/owl/payrit/domain/auth/dto/request/CertificationRequest.java
@@ -1,0 +1,7 @@
+package com.owl.payrit.domain.auth.dto.request;
+
+public record CertificationRequest(
+    String impUid
+) {
+
+}

--- a/src/main/java/com/owl/payrit/domain/auth/dto/request/PortOneTokenRequest.java
+++ b/src/main/java/com/owl/payrit/domain/auth/dto/request/PortOneTokenRequest.java
@@ -1,0 +1,12 @@
+package com.owl.payrit.domain.auth.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record PortOneTokenRequest(
+    String impKey,
+    String impSecret
+) {
+
+}

--- a/src/main/java/com/owl/payrit/domain/auth/dto/response/PortOneCertificationResponse.java
+++ b/src/main/java/com/owl/payrit/domain/auth/dto/response/PortOneCertificationResponse.java
@@ -1,0 +1,45 @@
+package com.owl.payrit.domain.auth.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.owl.payrit.domain.member.entity.CertificationInformation;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record PortOneCertificationResponse(
+    int code,
+    String message,
+    CertificationAnnotation certificationAnnotation
+) {
+
+    public CertificationInformation toEntity() {
+        return CertificationInformation.builder()
+                                       .impUid(certificationAnnotation.impUid)
+                                       .name(certificationAnnotation.name)
+                                       .gender(certificationAnnotation.gender)
+                                       .birthday(certificationAnnotation.birthday)
+                                       .phone(certificationAnnotation.phone)
+                                       .build();
+    }
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record CertificationAnnotation(
+        String impUid,
+        String merchantUid,
+        String pgTid,
+        String pgProvider,
+        String name,
+        String gender,
+        String birthday,
+        boolean foreigner,
+        String phone,
+        String carrier,
+        boolean certified,
+        Integer certifiedAt,
+        String uniqueKey,
+        String uniqueInSite,
+        String origin,
+        String foreignerV2
+    ) {
+
+    }
+}

--- a/src/main/java/com/owl/payrit/domain/auth/dto/response/PortOneTokenResponse.java
+++ b/src/main/java/com/owl/payrit/domain/auth/dto/response/PortOneTokenResponse.java
@@ -1,0 +1,21 @@
+package com.owl.payrit.domain.auth.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(SnakeCaseStrategy.class)
+public record PortOneTokenResponse(
+    int code,
+    String message,
+    AuthAnnotation authAnnotation
+) {
+
+    @JsonNaming(SnakeCaseStrategy.class)
+    public record AuthAnnotation(
+        String accessToken,
+        int expiredAt,
+        int now
+    ) {
+
+    }
+}

--- a/src/main/java/com/owl/payrit/domain/auth/dto/response/PortOneTokenResponse.java
+++ b/src/main/java/com/owl/payrit/domain/auth/dto/response/PortOneTokenResponse.java
@@ -9,7 +9,6 @@ public record PortOneTokenResponse(
     String message,
     AuthAnnotation authAnnotation
 ) {
-
     @JsonNaming(SnakeCaseStrategy.class)
     public record AuthAnnotation(
         String accessToken,
@@ -19,3 +18,5 @@ public record PortOneTokenResponse(
 
     }
 }
+
+

--- a/src/main/java/com/owl/payrit/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/owl/payrit/domain/auth/exception/AuthErrorCode.java
@@ -1,6 +1,7 @@
 package com.owl.payrit.domain.auth.exception;
 
 import static com.owl.payrit.global.consts.PayritStatic.BAD_REQUEST;
+import static com.owl.payrit.global.consts.PayritStatic.CONFLICT;
 import static com.owl.payrit.global.consts.PayritStatic.FORBIDDEN;
 import static com.owl.payrit.global.consts.PayritStatic.INTERNAL_SERVER;
 
@@ -19,6 +20,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     //OAUTH Error
     IMPROPER_OAUTH_INFORMATION(BAD_REQUEST, "OAUTH_400_1", "올바른 OAUTH 정보가 아닙니다."),
     NOT_AUTHORIZED_MEMBER(FORBIDDEN, "OAUTH_403_1", "인증되지 않은 유저입니다."),
+    ALREADY_USER_AUTHENTICATED(CONFLICT, "OAUTH_409_1", "이미 인증된 사용자입니다."),
+    IMMUTABLE_USER_AUTHENTICATED(CONFLICT, "OAUTH_409_1", "이미 인증된 계정이 존재합니다."),
     INTERNAL_SERVER_ERROR(INTERNAL_SERVER, "OAUTH_500_1", "OAUTH 서버 측 에러입니다. 다시 시도해주세요."),
     FILE_PATH_ERROR(INTERNAL_SERVER, "OAUTH_500_2", "Secret Key File 경로가 올바르지 않습니다.");
 

--- a/src/main/java/com/owl/payrit/domain/auth/provider/danal/PortOneApiClient.java
+++ b/src/main/java/com/owl/payrit/domain/auth/provider/danal/PortOneApiClient.java
@@ -1,0 +1,11 @@
+package com.owl.payrit.domain.auth.provider.danal;
+
+import com.owl.payrit.domain.auth.dto.request.PortOneTokenRequest;
+import com.owl.payrit.domain.auth.dto.response.PortOneTokenResponse;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface PortOneApiClient {
+
+    @PostExchange("https://api.iamport.kr/users/getToken")
+    PortOneTokenResponse getAccessToken(PortOneTokenRequest portOneTokenRequest);
+}

--- a/src/main/java/com/owl/payrit/domain/auth/provider/danal/PortOneApiClient.java
+++ b/src/main/java/com/owl/payrit/domain/auth/provider/danal/PortOneApiClient.java
@@ -1,11 +1,19 @@
 package com.owl.payrit.domain.auth.provider.danal;
 
 import com.owl.payrit.domain.auth.dto.request.PortOneTokenRequest;
+import com.owl.payrit.domain.auth.dto.response.PortOneCertificationResponse;
 import com.owl.payrit.domain.auth.dto.response.PortOneTokenResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
 public interface PortOneApiClient {
 
     @PostExchange("https://api.iamport.kr/users/getToken")
     PortOneTokenResponse getAccessToken(PortOneTokenRequest portOneTokenRequest);
+
+    @GetExchange("https://api.iamport.kr/certifications/{impUid}")
+    PortOneCertificationResponse getCertificationInformation(@RequestHeader(name = HttpHeaders.AUTHORIZATION) String bearerToken,  @PathVariable("impUid") String impUid);
 }

--- a/src/main/java/com/owl/payrit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/owl/payrit/domain/auth/service/AuthService.java
@@ -1,19 +1,26 @@
 package com.owl.payrit.domain.auth.service;
 
 import com.owl.payrit.domain.auth.domain.OauthProvider;
+import com.owl.payrit.domain.auth.dto.request.CertificationRequest;
 import com.owl.payrit.domain.auth.dto.request.LoginTokenRequest;
+import com.owl.payrit.domain.auth.dto.request.PortOneTokenRequest;
 import com.owl.payrit.domain.auth.dto.request.RevokeRequest;
 import com.owl.payrit.domain.auth.dto.response.LoginUser;
+import com.owl.payrit.domain.auth.dto.response.PortOneCertificationResponse;
+import com.owl.payrit.domain.auth.dto.response.PortOneTokenResponse;
 import com.owl.payrit.domain.auth.dto.response.TokenRefreshResponse;
 import com.owl.payrit.domain.auth.dto.response.TokenResponse;
 import com.owl.payrit.domain.auth.exception.AuthErrorCode;
 import com.owl.payrit.domain.auth.exception.AuthException;
 import com.owl.payrit.domain.auth.provider.OauthClientComposite;
+import com.owl.payrit.domain.auth.provider.danal.PortOneApiClient;
 import com.owl.payrit.domain.auth.util.JwtProvider;
+import com.owl.payrit.domain.member.entity.CertificationInformation;
 import com.owl.payrit.domain.member.entity.Member;
 import com.owl.payrit.domain.member.entity.OauthInformation;
 import com.owl.payrit.domain.member.service.MemberService;
 import com.owl.payrit.domain.promissorypaper.service.PromissoryPaperService;
+import com.owl.payrit.global.configuration.PortOneConfigProps;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +39,8 @@ public class AuthService {
     private final PromissoryPaperService promissoryPaperService;
     private final JwtProvider jwtProvider;
     private final RedisTemplate<OauthInformation, String> oauthRedisTemplate;
+    private final PortOneApiClient portOneApiClient;
+    private final PortOneConfigProps portOneConfigProps;
 
     @Value("${jwt.token.secret}")
     private String secretKey;
@@ -80,4 +89,39 @@ public class AuthService {
         String accessToken = jwtProvider.refreshAccessToken(loginTokenRequest.refreshToken(),secretKey);
         return new TokenRefreshResponse(accessToken, loginTokenRequest.refreshToken());
     }
+
+    @Transactional
+    public void initializeCertificationInformation(LoginUser loginUser, CertificationRequest certificationRequest) {
+        // 1. 기존에 본인인증 한 적이 있는지 확인합니다.
+        Member member = memberService.findById(loginUser.id());
+        checkIfUserAlreadyAuthenticated(member.isAuthenticated());
+        // 2. PortOne AccessToken을 요청합니다.
+        PortOneTokenRequest portOneTokenRequest = new PortOneTokenRequest(portOneConfigProps.getAccessKey(), portOneConfigProps.getSecretKey());
+        PortOneTokenResponse portOneTokenResponse = portOneApiClient.getAccessToken(portOneTokenRequest);
+
+        // 3. imp_uid를 통해 인증 된 정보를 가져옵니다.
+        PortOneCertificationResponse portOneCertificationResponse = portOneApiClient.getCertificationInformation(portOneTokenResponse.authAnnotation().accessToken(), certificationRequest.impUid());
+        CertificationInformation certificationInformation = portOneCertificationResponse.toEntity();
+
+        // 4. 기존에 다른 아이디로 본인인증 된 적이 있는지 확인합니다.
+        checkCertificationInformationExistence(certificationInformation.getName(), certificationInformation.getPhone());
+
+        // 5. 유저의 본인인증 정보를 업데이트 합니다.
+        member.updateCertificationInformation(certificationInformation);
+
+    }
+
+    public void checkCertificationInformationExistence(String name, String phone) {
+        boolean exists = memberService.existsByCertificationInformation(name, phone);
+        if (exists) {
+            throw new AuthException(AuthErrorCode.IMMUTABLE_USER_AUTHENTICATED);
+        }
+    }
+
+    public void checkIfUserAlreadyAuthenticated(boolean isAuthenticated) {
+        if(isAuthenticated) {
+            throw new AuthException(AuthErrorCode.ALREADY_USER_AUTHENTICATED);
+        }
+    }
+
 }

--- a/src/main/java/com/owl/payrit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/owl/payrit/domain/auth/service/AuthService.java
@@ -100,7 +100,7 @@ public class AuthService {
         PortOneTokenResponse portOneTokenResponse = portOneApiClient.getAccessToken(portOneTokenRequest);
 
         // 3. imp_uid를 통해 인증 된 정보를 가져옵니다.
-        PortOneCertificationResponse portOneCertificationResponse = portOneApiClient.getCertificationInformation(portOneTokenResponse.authAnnotation().accessToken(), certificationRequest.impUid());
+        PortOneCertificationResponse portOneCertificationResponse = portOneApiClient.getCertificationInformation("Bearer %s".formatted(portOneTokenResponse.authAnnotation().accessToken()), certificationRequest.impUid());
         CertificationInformation certificationInformation = portOneCertificationResponse.toEntity();
 
         // 4. 기존에 다른 아이디로 본인인증 된 적이 있는지 확인합니다.

--- a/src/main/java/com/owl/payrit/domain/member/entity/CertificationInformation.java
+++ b/src/main/java/com/owl/payrit/domain/member/entity/CertificationInformation.java
@@ -1,6 +1,8 @@
 package com.owl.payrit.domain.member.entity;
 
+import com.owl.payrit.global.encryption.PromissoryPaperStringConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,15 +21,19 @@ public class CertificationInformation {
     private String impUid;
 
     @Column(name = "certification_name")
+    @Convert(converter = PromissoryPaperStringConverter.class)
     private String name;
 
     @Column(name = "certification_gender")
+    @Convert(converter = PromissoryPaperStringConverter.class)
     private String gender;
 
     @Column(name = "certification_birthday")
+    @Convert(converter = PromissoryPaperStringConverter.class)
     private String birthday;
 
     @Column(name = "certification_phone_number")
+    @Convert(converter = PromissoryPaperStringConverter.class)
     private String phone;
 
 }

--- a/src/main/java/com/owl/payrit/domain/member/entity/CertificationInformation.java
+++ b/src/main/java/com/owl/payrit/domain/member/entity/CertificationInformation.java
@@ -1,0 +1,31 @@
+package com.owl.payrit.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Embeddable
+public class CertificationInformation {
+
+    @Column(name = "imp_uid")
+    private String impUid;
+
+    @Column(name = "certification_name")
+    private String name;
+
+    @Column(name = "certification_gender")
+    private String gender;
+
+    @Column(name = "certification_birthday")
+    private String birthday;
+
+    @Column(name = "certification_phone_number")
+    private String phone;
+
+}

--- a/src/main/java/com/owl/payrit/domain/member/entity/CertificationInformation.java
+++ b/src/main/java/com/owl/payrit/domain/member/entity/CertificationInformation.java
@@ -4,10 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Embeddable

--- a/src/main/java/com/owl/payrit/domain/member/entity/Member.java
+++ b/src/main/java/com/owl/payrit/domain/member/entity/Member.java
@@ -45,6 +45,9 @@ public class Member extends BaseEntity implements UserDetails {
     @Embedded
     private OauthInformation oauthInformation;
 
+    @Embedded
+    private CertificationInformation certificationInformation;
+
     @Column(nullable = false)
     private String email;
 

--- a/src/main/java/com/owl/payrit/domain/member/entity/Member.java
+++ b/src/main/java/com/owl/payrit/domain/member/entity/Member.java
@@ -88,6 +88,10 @@ public class Member extends BaseEntity implements UserDetails {
         this.firebaseToken = firebaseToken;
     }
 
+    public void updateCertificationInformation(CertificationInformation certificationInformation) {
+        this.certificationInformation = certificationInformation;
+        this.isAuthenticated = true;
+    }
     @Override
     public String getPassword() {
         return null;

--- a/src/main/java/com/owl/payrit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/owl/payrit/domain/member/repository/MemberRepository.java
@@ -12,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByPhoneNumber(String phoneNumber);
     Optional<Member> findByNameAndPhoneNumber(String name, String phoneNumber);
     boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+    boolean existsByCertificationInformationNameAndCertificationInformationPhone(String name, String phone);
 }

--- a/src/main/java/com/owl/payrit/domain/member/service/MemberService.java
+++ b/src/main/java/com/owl/payrit/domain/member/service/MemberService.java
@@ -62,4 +62,8 @@ public class MemberService {
     public void delete(Member member) {
         memberRepository.delete(member);
     }
+
+    public boolean existsByCertificationInformation(String name, String phone) {
+        return memberRepository.existsByCertificationInformationNameAndCertificationInformationPhone(name, phone);
+    }
 }

--- a/src/main/java/com/owl/payrit/global/configuration/PortOneConfigProps.java
+++ b/src/main/java/com/owl/payrit/global/configuration/PortOneConfigProps.java
@@ -14,4 +14,5 @@ public class PortOneConfigProps {
     private String storeId;
     private String accessKey;
     private String secretKey;
+
 }

--- a/src/main/java/com/owl/payrit/global/testutil/FakeKakaoMemberClient.java
+++ b/src/main/java/com/owl/payrit/global/testutil/FakeKakaoMemberClient.java
@@ -21,7 +21,7 @@ public class FakeKakaoMemberClient implements OauthClient {
     public Member fetch(String accessToken) {
         // 가짜 유저 정보를 생성하여 반환
         OauthInformation fakeOauthInformation = new OauthInformation("fake_oauth_provider_id", OauthProvider.FAKE_KAKAO);
-        return new Member(fakeOauthInformation, "fake_email@example.com", "fake_phone_number", LocalDate.now(),"test",true, true, "fake_firebase_token", "fake_address", Role.MEMBER);
+        return new Member(fakeOauthInformation, null ,"fake_email@example.com", "fake_phone_number", LocalDate.now(),"test",true, true, "fake_firebase_token", "fake_address", Role.MEMBER);
     }
 
     @Override


### PR DESCRIPTION
!! 본인인증 모듈 오류로 승인하지 마시고 내용만 확인해 주세요!!

1. 차용증 작성에 필요한 정보들이 Member.CertificationInformation 안으로 들어갔습니다. 따라서, 차용증 작성 로직에 자동으로 가져오는 부분들에 대해서 변경이 필요할 것 같아요.

2. 1번에 의해 기존 Member Entity에 존재하는 name이나 phoneNumber 같은 부분이 제거되어도 될 것 같은데, 당장에 제거하면 컴파일 오류와 더불어서 여러 문제들이 있어서 일단 그대로 존재합니다.

3. CertificationInformation 클래스의 birth와 같은 필드는 기존 Member의 LocalDate와 타입이 일치하지 않습니다. 일단은 제공해주는 양식대로 맞춰놨는데, 추후에 변경 할 계획입니다.